### PR TITLE
Auto Release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,8 @@ jobs:
       run: dotnet publish src/AzureDevOps2GitHubMigrator.csproj --configuration Release --output ./publish --no-restore
       
     - name: Zip Release
-      run: cd publish && zip -r ../AzureDevOps2GitHubMigrator.zip *
+      run: |
+        powershell -Command "Compress-Archive -Path publish\* -DestinationPath AzureDevOps2GitHubMigrator.zip"
       
     - name: Create Release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,10 @@ on:
   push:
     tags:
       - 'v*'
-permissions:
-  contents: write
+
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use a Windows-based environment instead of Ubuntu and adjusts commands to be compatible with Windows. Below are the most important changes:

### Workflow Environment Updates:
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L11-R11): Changed the `runs-on` environment from `ubuntu-latest` to `windows-latest` for the `build` job.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L7-R10): Changed the `runs-on` environment from `ubuntu-latest` to `windows-latest` for the `release` job.

### Command Adjustments for Windows Compatibility:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L34-R34): Replaced the Linux `zip` command with a PowerShell `Compress-Archive` command for zipping the release files.