### PR TITLE
fix: improve team retrieval by using slug in API call

### DIFF
--- a/src/Services/GitHubService.cs
+++ b/src/Services/GitHubService.cs
@@ -325,8 +325,14 @@ public class GitHubService
     {
         try
         {
-            var teams = await InvokeApiAsync<List<GitHubTeamInfo>>($"orgs/{organization}/teams", HttpMethod.Get, cancellationToken: cancellationToken);
-            return teams?.FirstOrDefault(t => t.Name == teamName || t.Slug == teamName.ToLowerInvariant());
+            var teamSlug = teamName.ToLower().Replace(" ", "-");
+            var team = await InvokeApiAsync<GitHubTeamInfo>($"orgs/{organization}/teams/{teamSlug}", HttpMethod.Get, cancellationToken: cancellationToken);
+            if (team != null)
+            {
+                Logger.LogSuccess($"Found team {teamName}");
+                return team;
+            }
+            return null;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
This pull request refines the logic for retrieving a team by its name in the `AddTeamMemberAsync` method of `GitHubService`. The change improves the accuracy of team lookups by using a more precise API endpoint and logging successful lookups.

### Improvements to team lookup logic:

* [`src/Services/GitHubService.cs`](diffhunk://#diff-2a303a4a8d05f28c7f3fe5d999f62462b30cfbc6db129bc33a029e434a6e9fccL328-R335): Updated the `AddTeamMemberAsync` method to use the `teams/{teamSlug}` API endpoint instead of fetching all teams and filtering them. This change enhances efficiency and ensures accurate team retrieval by converting the team name to a slug format. Additionally, a success log message is added when a team is found.Refactor the team retrieval logic to use the team's slug instead of searching through the list of teams. This change enhances the efficiency of the API call and ensures accurate team identification by replacing spaces with hyphens in the team name.