### PR TITLE
Bug fix get team

### DIFF
--- a/src/Models/GitHub/GitHubTeamInfo.cs
+++ b/src/Models/GitHub/GitHubTeamInfo.cs
@@ -10,5 +10,5 @@ public class GitHubTeamInfo
     public string? Permission { get; set; }
     public string? Url { get; set; }
     public string? HtmlUrl { get; set; }
-    public string? Organization { get; set; }
+    public string? OrganizationName { get; set; }
 }

--- a/src/Services/GitHubService.cs
+++ b/src/Services/GitHubService.cs
@@ -325,8 +325,14 @@ public class GitHubService
     {
         try
         {
-            var teams = await InvokeApiAsync<List<GitHubTeamInfo>>($"orgs/{organization}/teams", HttpMethod.Get, cancellationToken: cancellationToken);
-            return teams?.FirstOrDefault(t => t.Name == teamName || t.Slug == teamName.ToLowerInvariant());
+            var teamSlug = teamName.ToLower().Replace(" ", "-");
+            var team = await InvokeApiAsync<GitHubTeamInfo>($"orgs/{organization}/teams/{teamSlug}", HttpMethod.Get, cancellationToken: cancellationToken);
+            if (team != null)
+            {
+                Logger.LogSuccess($"Found team {teamName}");
+                return team;
+            }
+            return null;
         }
         catch (Exception ex)
         {

--- a/src/Services/GitHubService.cs
+++ b/src/Services/GitHubService.cs
@@ -330,6 +330,7 @@ public class GitHubService
             if (team != null)
             {
                 Logger.LogSuccess($"Found team {teamName}");
+                team.OrganizationName = organization;
                 return team;
             }
             return null;


### PR DESCRIPTION
This pull request includes updates to the `GitHubTeamInfo` model and the `AddTeamMemberAsync` method in the `GitHubService` class to improve clarity and functionality. The most important changes involve renaming a property for better naming consistency and modifying the logic for retrieving a GitHub team.

### Updates to the `GitHubTeamInfo` model:
* Renamed the `Organization` property to `OrganizationName` for improved clarity and consistency in naming conventions. (`src/Models/GitHub/GitHubTeamInfo.cs`, [src/Models/GitHub/GitHubTeamInfo.csL13-R13](diffhunk://#diff-bb26f4e7049eedfd0a307cf20d4488dfc3e171d04eb832eace680a259593c60dL13-R13))

### Improvements to the `AddTeamMemberAsync` method:
* Updated the logic to retrieve a specific GitHub team using a slugified version of the team name, replacing the previous approach of fetching all teams and filtering them. This change improves efficiency and reduces unnecessary API calls. (`src/Services/GitHubService.cs`, [src/Services/GitHubService.csL328-R336](diffhunk://#diff-2a303a4a8d05f28c7f3fe5d999f62462b30cfbc6db129bc33a029e434a6e9fccL328-R336))
* Added logging to indicate when a team is successfully found, providing better traceability during execution. (`src/Services/GitHubService.cs`, [src/Services/GitHubService.csL328-R336](diffhunk://#diff-2a303a4a8d05f28c7f3fe5d999f62462b30cfbc6db129bc33a029e434a6e9fccL328-R336))
* Set the `OrganizationName` property of the retrieved team object to the organization name, ensuring that this information is consistently populated. (`src/Services/GitHubService.cs`, [src/Services/GitHubService.csL328-R336](diffhunk://#diff-2a303a4a8d05f28c7f3fe5d999f62462b30cfbc6db129bc33a029e434a6e9fccL328-R336))